### PR TITLE
(#107, #110) 버전 상태 변경시 Webview 강제 리로드, iOS에서 로그인 직후 까만 화면이 꽤 오래 나오는 현상 개선

### DIFF
--- a/src/apis/API.ts
+++ b/src/apis/API.ts
@@ -39,7 +39,7 @@ const API = (() => {
   apiInstance.interceptors.response.use(
     (config) => {
       console.log('[API response]', config);
-      return config;
+      return config.data;
     },
     (err) => {
       console.log('[API response error]', err);

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -1,3 +1,4 @@
 export * as pushNotificationApis from './pushNotification.api';
 export * as momentApis from './moment.api';
 export * as notificationApis from './notification.api';
+export * as userApis from './user.api';

--- a/src/apis/user.api.ts
+++ b/src/apis/user.api.ts
@@ -1,0 +1,9 @@
+import { UserType } from '@types';
+import ApiService from './API';
+
+const { API } = ApiService;
+
+export const getMe = async () => {
+  const res = await API.get<UserType.MyProfile>('/user/me/');
+  return res;
+};

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -6,3 +6,4 @@ export { default as useCameraDevice } from './useCameraDevice';
 export { CameraImage, default as useCamera } from './useCamera';
 export { default as useNavigationService } from './useNavigationService';
 export { default as useFirebaseMessage } from './useFirebaseMessage';
+export { default as useVersionInfo } from './useVersionInfo';

--- a/src/hooks/useVersionInfo.ts
+++ b/src/hooks/useVersionInfo.ts
@@ -61,7 +61,14 @@ const useVersionInfo = () => {
         if (hasChanged) {
           await userVersionStorage.checkAndUpdate(currentVersion);
           setUserVersion(currentVersion);
-          console.log('[useVersionInfo] Version updated:', currentVersion);
+          console.log(
+            '🔄 [useVersionInfo] Version Change Detected!\n',
+            '📱 Previous Version:',
+            storedVersion,
+            '\n',
+            '✨ New Version:',
+            currentVersion,
+          );
         }
 
         lastCheckTime.current = Date.now();

--- a/src/hooks/useVersionInfo.ts
+++ b/src/hooks/useVersionInfo.ts
@@ -1,10 +1,23 @@
-import { useState } from 'react';
+import { useState, useRef, useCallback } from 'react';
 import { userApis } from '@apis';
 import { userVersionStorage } from '@tools';
 import { VersionType } from '../types/user.type';
 
+const DEBOUNCE_TIME = 1000; // 1초
+
+type VersionCheckResult = {
+  hasChanged: boolean;
+  currentVersion?: string;
+  storedVersion?: string | null;
+  error?: any;
+} | null;
+
 const useVersionInfo = () => {
   const [userVersion, setUserVersion] = useState<string | null>(null);
+  const lastCheckTime = useRef<number>(0);
+  const isChecking = useRef<boolean>(false);
+  const initializeAttempts = useRef<number>(0);
+  const MAX_ATTEMPTS = 2;
 
   // 현재 storage에 저장된 version을 가져오는 함수
   const getStoredVersion = async () => {
@@ -20,34 +33,68 @@ const useVersionInfo = () => {
   };
 
   // API로부터 최신 버전을 가져와서 storage의 버전과 비교하는 함수
-  const checkAndUpdateVersion = async () => {
-    try {
-      console.log('checkAndUpdateVersion');
-      const meResponse = await userApis.getMe();
-      const currentVersion = meResponse.current_ver ?? VersionType.DEFAULT;
+  const checkAndUpdateVersion =
+    useCallback(async (): Promise<VersionCheckResult> => {
+      const now = Date.now();
 
-      const storedVersion = await userVersionStorage.get();
-      const hasChanged = storedVersion !== currentVersion;
-
-      if (hasChanged) {
-        await userVersionStorage.checkAndUpdate(currentVersion);
-        setUserVersion(currentVersion);
-        console.log('[useVersionInfo] Version updated:', currentVersion);
+      if (isChecking.current || now - lastCheckTime.current < DEBOUNCE_TIME) {
+        console.log(
+          '[useVersionInfo] Skip version check - too frequent or already checking',
+        );
+        return null;
       }
 
-      return {
-        hasChanged,
-        currentVersion,
-        storedVersion,
-      };
-    } catch (error) {
-      console.error('[useVersionInfo] Error checking version:', error);
-      return {
-        hasChanged: false,
-        error,
-      };
-    }
-  };
+      try {
+        isChecking.current = true;
+        console.log(
+          '[useVersionInfo] Checking version... Attempt:',
+          initializeAttempts.current + 1,
+        );
+
+        const meResponse = await userApis.getMe();
+        console.log('[useVersionInfo] getMe API response:', meResponse);
+
+        const currentVersion = meResponse.current_ver ?? VersionType.DEFAULT;
+        const storedVersion = await userVersionStorage.get();
+        const hasChanged = storedVersion !== currentVersion;
+
+        if (hasChanged) {
+          await userVersionStorage.checkAndUpdate(currentVersion);
+          setUserVersion(currentVersion);
+          console.log('[useVersionInfo] Version updated:', currentVersion);
+        }
+
+        lastCheckTime.current = Date.now();
+        initializeAttempts.current = 0; // 성공하면 시도 횟수 리셋
+
+        return {
+          hasChanged,
+          currentVersion,
+          storedVersion,
+        };
+      } catch (error) {
+        console.error('[useVersionInfo] Error checking version:', error);
+
+        // 최대 시도 횟수를 초과하지 않았다면 재시도
+        if (initializeAttempts.current < MAX_ATTEMPTS) {
+          initializeAttempts.current += 1;
+          console.log(
+            '[useVersionInfo] Retrying... Attempt:',
+            initializeAttempts.current,
+          );
+          // 잠시 대기 후 재시도
+          await new Promise((resolve) => setTimeout(resolve, 1000));
+          return checkAndUpdateVersion();
+        }
+
+        return {
+          hasChanged: false,
+          error,
+        };
+      } finally {
+        isChecking.current = false;
+      }
+    }, []);
 
   return {
     userVersion,

--- a/src/hooks/useVersionInfo.ts
+++ b/src/hooks/useVersionInfo.ts
@@ -1,0 +1,59 @@
+import { useState } from 'react';
+import { userApis } from '@apis';
+import { userVersionStorage } from '@tools';
+import { VersionType } from '../types/user.type';
+
+const useVersionInfo = () => {
+  const [userVersion, setUserVersion] = useState<string | null>(null);
+
+  // 현재 storage에 저장된 version을 가져오는 함수
+  const getStoredVersion = async () => {
+    try {
+      const version = await userVersionStorage.get();
+      console.log('[useVersionInfo] Stored user version:', version);
+      setUserVersion(version);
+      return version;
+    } catch (error) {
+      console.error('[useVersionInfo] Error getting stored version:', error);
+      return null;
+    }
+  };
+
+  // API로부터 최신 버전을 가져와서 storage의 버전과 비교하는 함수
+  const checkAndUpdateVersion = async () => {
+    try {
+      console.log('checkAndUpdateVersion');
+      const meResponse = await userApis.getMe();
+      const currentVersion = meResponse.current_ver ?? VersionType.DEFAULT;
+
+      const storedVersion = await userVersionStorage.get();
+      const hasChanged = storedVersion !== currentVersion;
+
+      if (hasChanged) {
+        await userVersionStorage.checkAndUpdate(currentVersion);
+        setUserVersion(currentVersion);
+        console.log('[useVersionInfo] Version updated:', currentVersion);
+      }
+
+      return {
+        hasChanged,
+        currentVersion,
+        storedVersion,
+      };
+    } catch (error) {
+      console.error('[useVersionInfo] Error checking version:', error);
+      return {
+        hasChanged: false,
+        error,
+      };
+    }
+  };
+
+  return {
+    userVersion,
+    getStoredVersion,
+    checkAndUpdateVersion,
+  };
+};
+
+export default useVersionInfo;

--- a/src/screens/AppScreen/AppScreen.tsx
+++ b/src/screens/AppScreen/AppScreen.tsx
@@ -53,10 +53,12 @@ const AppScreen: React.FC<AppScreenProps> = ({ route }) => {
   useAppStateActiveEffect(syncPushNotiPermission);
   useAsyncEffect(syncPushNotiPermission, []);
 
+  // 푸시 권한 허용 요청
   useAsyncEffect(async () => {
     await requestPermissionIfNot();
   }, []);
 
+  // 버전 체크 및 업데이트
   useEffect(() => {
     const initializeVersion = async () => {
       try {
@@ -68,6 +70,19 @@ const AppScreen: React.FC<AppScreenProps> = ({ route }) => {
 
     initializeVersion();
   }, []);
+
+  // 앱이 활성화될 때마다 버전 체크
+  useAppStateActiveEffect(() => {
+    const checkVersionOnActive = async () => {
+      try {
+        await checkAndUpdateVersion();
+      } catch (error) {
+        console.error('[AppScreen] Error in version check on active:', error);
+      }
+    };
+
+    checkVersionOnActive();
+  });
 
   useEffect(() => {
     BackHandler.addEventListener(

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -3,3 +3,4 @@ export * from './cookieStorage';
 export * from './languageHelper';
 export * from './permissionHelper';
 export * from './cookieHelper';
+export * from './userVersionStorage';

--- a/src/tools/userVersionStorage.ts
+++ b/src/tools/userVersionStorage.ts
@@ -1,0 +1,27 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { VersionType } from '../types/user.type';
+
+const USER_VERSION_KEY = '@user_version';
+
+export const userVersionStorage = {
+  get: () => AsyncStorage.getItem(USER_VERSION_KEY),
+
+  checkAndUpdate: async (currentVer: VersionType) => {
+    console.log('[UserVersionStorage] Checking version:', currentVer);
+    const previousVersion = await AsyncStorage.getItem(USER_VERSION_KEY);
+
+    console.log('[UserVersionStorage] Version comparison:', {
+      currentVer,
+      previousVersion,
+    });
+
+    if (previousVersion !== currentVer) {
+      await AsyncStorage.setItem(
+        USER_VERSION_KEY,
+        currentVer || VersionType.DEFAULT,
+      );
+      return true;
+    }
+    return false;
+  },
+};

--- a/src/types/checkIn.type.ts
+++ b/src/types/checkIn.type.ts
@@ -1,0 +1,34 @@
+export enum Availability {
+  available = 'available',
+  busy = 'busy',
+  might_get_distracted = 'might_get_distracted',
+  urgent_only = 'urgent_only',
+  about_to_sleep = 'about_to_sleep',
+  studying = 'studying',
+  in_transit = 'in_transit',
+  feeling_social = 'feeling_social',
+  feeling_quiet = 'feeling_quiet',
+}
+
+export type CheckInBase = {
+  id: number;
+  is_active: boolean;
+  created_at: string;
+  mood: string;
+  availability: Availability | null;
+  description: string;
+  track_id: string;
+  current_user_read: boolean;
+};
+
+export type MyCheckIn = CheckInBase & {
+  share_everyone: boolean;
+  // FIXME: share_everyone, share_groups, share_friends의 타입 수정 필요
+  share_groups: any[];
+  shrare_friends: any[];
+};
+
+export type CheckInForm = Omit<
+  CheckInBase,
+  'id' | 'is_active' | 'created_at' | 'current_user_read'
+>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,3 +2,5 @@ export * as DynamicLinkType from './dynamicLink.type';
 export * as RouteType from './route.type';
 export * as MomentType from './moment.type';
 export * as CookieType from './cookie.type';
+export * as UserType from './user.type';
+export * as CheckInType from './checkIn.type';

--- a/src/types/user.type.ts
+++ b/src/types/user.type.ts
@@ -1,0 +1,153 @@
+import { MyCheckIn } from './checkIn.type';
+
+export interface User {
+  id: number;
+  profile_image: string | null;
+  profile_pic: string;
+  url: string;
+  username: string;
+  bio: string;
+  pronouns: string;
+}
+
+export interface SignInParams {
+  username: string;
+  password: string;
+}
+
+export interface SignInResponse {
+  access: string;
+  refresh: string;
+}
+export interface SignInError {
+  code: SignInErrorCodeType;
+  detail: string;
+}
+
+const SignInErrorCode = {
+  NO_USERNAME: 'username_does_not_exist',
+  WRONG_PASSWORD: 'wrong_password',
+} as const;
+
+type SignInErrorCodeType =
+  (typeof SignInErrorCode)[keyof typeof SignInErrorCode];
+
+export interface SignUpParams {
+  email: string;
+  username: string;
+  password: string;
+  /** default: 16:00 */
+  noti_time?: string;
+}
+
+export const hasMandatorySignUpParams = (
+  signUpParams: Partial<SignUpParams>,
+): signUpParams is SignUpParams =>
+  !!signUpParams.email && !!signUpParams.username && !!signUpParams.password;
+
+export enum Gender {
+  FEMALE,
+  MALE,
+  TRANSGENDER,
+  NON_BINARY,
+  NO_RESPOND,
+}
+export interface EmailError {
+  detail: EmailValidateErrorType;
+}
+
+export const EmailValidateError = {
+  ALREADY_EXIST_KO: '이미 가입된 이메일입니다',
+  ALREADY_EXIST_EN: 'An account with this email already exists.',
+  INVALID_EMAIL_FORMAT_KO: '유효하지 않은 이메일 형식입니다.',
+  INVALID_EMAIL_FORMAT_EN: 'Email format is invalid.',
+} as const;
+
+export type EmailValidateErrorType =
+  (typeof EmailValidateError)[keyof typeof EmailValidateError];
+
+export interface PasswordError {
+  password: PasswordValidateErrorType[];
+}
+
+export interface PasswordConfirmError {
+  code: 'wrong_password';
+  detail: 'Please check your password.' | '비밀번호를 다시 확인해주세요.';
+}
+
+export const PasswordValidateError = {
+  MUST_INCLUDE_NUM_KO: '비밀번호는 숫자(0-9)를 한 개 이상 포함해야 합니다',
+  MUST_INCLUDE_NUM_EN: 'Your password must contain at least 1 digit, 0-9.',
+  MUST_INCLUDE_ALPHABET_UPPER_KO:
+    '비밀번호는 알파벳 대문자(A-Z)를 한 개 이상 포함해야 합니다.',
+  MUST_INCLUDE_ALPHABET_UPPER_EN:
+    'Your password must contain at least 1 uppercase letter, A-Z.',
+  MUST_INCLUDE_ALPHABET_LOWER_KO:
+    '비밀번호는 알파벳 소문자(a-z)를 한 개 이상 포함해야 합니다.',
+  MUST_INCLUDE_ALPHABET_LOWER_EN:
+    'Your password must contain at least 1 lowercase letter, a-z.',
+  MUST_INCLUDE_SPECIAL_CHAR_KO:
+    '비밀번호는 특수문자를 한 개 이상 포함해야 합니다: ()[]{}|\\`~!@#$%^&*_-+=;:\'",<>./?',
+  MUST_INCLUDE_SPECIAL_CHAR_EN:
+    'Your password must contain at least 1 symbol: ()[]{}|\\`~!@#$%^&*_-+=;:\'",<>./?',
+} as const;
+
+export type PasswordValidateErrorType =
+  (typeof PasswordValidateError)[keyof typeof PasswordValidateError];
+
+export interface UsernameError {
+  detail: UsernameValidateErrorType;
+}
+
+export const UsernameValidateError = {
+  ALREADY_EXIST_KO: '이미 존재하는 닉네임입니다.',
+  ALREADY_EXIST_EN: 'Username already exists.',
+  NO_MORE_THAN_20_CHAR_KO: '닉네임은 20글자 이하로 설정해주세요.',
+  NO_MORE_THAN_20_CHAR_EN: 'Username must be shorter than 21 letters.',
+  CHAR_CONSTRAINTS_KO:
+    '유효하지 않은 닉네임입니다. 닉네임은 영어, 한글, 숫자, 특수문자(_)만 포함할 수 있습니다.',
+  CHAR_CONSTRAINTS_EN:
+    'Username format is invalid. Usernames can only include letters (alphabet/Korean), numbers and underscores(_).',
+} as const;
+
+export type UsernameValidateErrorType =
+  (typeof UsernameValidateError)[keyof typeof UsernameValidateError];
+
+export type DayOfWeek = '0' | '1' | '2' | '3' | '4' | '5' | '6'; // 0 = Sunday, 1 = Monday, etc.
+
+export enum VersionType {
+  DEFAULT = 'default',
+  EXPERIMENT = 'experiment',
+}
+
+export interface MyProfile extends User {
+  email: string;
+  date_of_birth: string | null;
+  date_of_signature: string | null;
+  ethnicity: unknown;
+  gender: Gender;
+  nationality: unknown;
+  question_history: number[] | null;
+  research_agreement: boolean;
+  signature: string | null;
+  url: string;
+  noti_time: string;
+  noti_period_days: DayOfWeek[];
+  unread_noti: boolean;
+  timezone?: string;
+  check_in?: MyCheckIn;
+  current_ver: VersionType;
+}
+
+export interface FriendRequest {
+  requestee_id: number;
+  requester_id: number;
+  requester_detail: User;
+  accepted: boolean;
+}
+
+export interface SentFriendRequest {
+  requestee_id: number;
+  requester_id: number;
+  requestee_detail: User;
+}


### PR DESCRIPTION
## Issue Number: #107 #110

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?

- 앱에 들어올때마다 getMe를 호출해서 버전 상태가 변경된 것을 확인하면 webview를 강제 리로드하도록 한다
- 로그인 직후 까만 화면이 오래 나오는 현상 개선 (webview reload 조건 개선)

## Preview Image

- 버전이 바뀌면 reload되는 것 확인 (아래 로그와 같은 타이밍에)

![CleanShot 2025-02-22 at 10 24 05](https://github.com/user-attachments/assets/39e12847-121e-4ab8-b183-a2388b5ff80e)


- 로그인 직후 reload 때문에 까만 화면이 나오는 조건 개선
불필요한 조건에서도 relaod가 되고 있어서 문제였음을 확인
다른 계정으로 직후에 로그인했을때에도 문제 없는 것 확인

![Simulator Screen Recording - iPhone 15 - 2025-02-22 at 08 45 10](https://github.com/user-attachments/assets/0b2fc421-6e4a-495d-bed9-230f156d9b41)

## Further comments
