### PR TITLE
feat(analytics): forward web ANALYTICS_* postMessages to Firebase

### DIFF
--- a/src/hooks/useAnalytics.tsx
+++ b/src/hooks/useAnalytics.tsx
@@ -43,6 +43,50 @@ const useAnalytics = (tokens: {
     }
   };
 
+  // Generic counterpart to trackEvent for events forwarded from the
+  // WebView (browse_mode_picked, etc.). Same fire-and-forget behaviour.
+  const trackBridgedEvent = async (
+    eventName: string,
+    params?: Record<string, any>,
+  ) => {
+    try {
+      await analyticsInstance.logEvent(eventName, { ...params });
+    } catch (e) {
+      console.log('[useAnalytics] bridged logEvent failed', eventName, e);
+    }
+  };
+
+  const trackBridgedScreenView = async (params: {
+    page_name: string;
+    page_path: string;
+  }) => {
+    try {
+      await analyticsInstance.logScreenView({
+        screen_name: params.page_name,
+        screen_class: params.page_path,
+      });
+    } catch (e) {
+      console.log('[useAnalytics] bridged logScreenView failed', e);
+    }
+  };
+
+  const setBridgedUserProperties = async (props: Record<string, any>) => {
+    try {
+      const { user_id, ...rest } = props;
+      if (user_id !== undefined && user_id !== null) {
+        await analyticsInstance.setUserId(String(user_id));
+      }
+      // Firebase requires string values for setUserProperties.
+      const stringProps: Record<string, string> = {};
+      Object.entries(rest).forEach(([k, v]) => {
+        stringProps[k] = v === null || v === undefined ? '' : String(v);
+      });
+      await analyticsInstance.setUserProperties(stringProps);
+    } catch (e) {
+      console.log('[useAnalytics] bridged setUserProperties failed', e);
+    }
+  };
+
   const handleAppStateChange = useCallback(async (state: AppStateStatus) => {
     if (state.match(/inactive|background/)) {
       console.log('[useAnalytics] App is inactive or background');
@@ -92,6 +136,9 @@ const useAnalytics = (tokens: {
     setUserProperties,
     trackEvent,
     handleLogout,
+    trackBridgedEvent,
+    trackBridgedScreenView,
+    setBridgedUserProperties,
   };
 };
 

--- a/src/hooks/useWebView.ts
+++ b/src/hooks/useWebView.ts
@@ -27,7 +27,12 @@ const useWebView = () => {
   const { getCookie } = CookieStorage;
   const { registerOrUpdatePushToken } = useFirebaseMessage();
   const [isCanGoBack, setIsCanGoBack] = useState(false);
-  const { handleLogout } = useAnalytics(tokens);
+  const {
+    handleLogout,
+    trackBridgedEvent,
+    trackBridgedScreenView,
+    setBridgedUserProperties,
+  } = useAnalytics(tokens);
   const postMessage = useCallback((key: string, data: any) => {
     ref.current?.postMessage(JSON.stringify({ key, data }));
   }, []);
@@ -202,11 +207,33 @@ const useWebView = () => {
         case 'OPEN_CAMERA':
           openCamera();
           return;
+        // Analytics bridge: the web frontend already emits rich
+        // page-view / event / user-property messages, but they were
+        // being dropped here. Forward them to Firebase Analytics so
+        // research dashboards see route-level + feature-level traffic.
+        case 'ANALYTICS_TRACK_EVENT':
+          trackBridgedEvent(data.name, data.params);
+          return;
+        case 'ANALYTICS_PAGE_VIEW':
+          trackBridgedScreenView({
+            page_name: data.page_name,
+            page_path: data.page_path,
+          });
+          return;
+        case 'ANALYTICS_SET_USER':
+          setBridgedUserProperties(data);
+          return;
         default:
           return;
       }
     },
-    [openCamera, openGallery],
+    [
+      openCamera,
+      openGallery,
+      trackBridgedEvent,
+      trackBridgedScreenView,
+      setBridgedUserProperties,
+    ],
   );
 
   const onLoadProgress = useCallback((e: WebViewProgressEvent) => {


### PR DESCRIPTION
## Summary

The web frontend has been emitting \`ANALYTICS_PAGE_VIEW\`, \`ANALYTICS_TRACK_EVENT\`, and \`ANALYTICS_SET_USER\` postMessages on every route change, screen-dwell completion, and profile load. The WebView's \`onMessage\` switch had no cases for them, so every event was silently dropped.

Add three switch cases that forward each shape to the matching \`@react-native-firebase/analytics\` call. Once shipped, Firebase Console will start receiving:

- Per-route \`screen_view\` events
- \`screen_dwell\` events (page name + duration ms) — answers "average time on each screen"
- App lifecycle (\`app_foreground\` / \`app_background\`) — answers "session length"
- Rich user properties (gender, age_range, friend_count_tier, current_ver, user_group, etc.) — enables cohort analysis in Firebase Console
- Per-feature events from the web (e.g. the \`browse_mode_picked\` event added in WhoamI-Today-frontend#1308's follow-up)

## Why now

The web team is actively shipping client-only behavior tracking (browse-mode picker funnel, compose-flow abandonments, etc.) where the only research-analytics path is Firebase. Without these handlers wired, none of that data lands anywhere.

## Changes
- \`useAnalytics.tsx\` — add \`trackBridgedEvent\`, \`trackBridgedScreenView\`, \`setBridgedUserProperties\` helpers (mirror existing \`trackEvent\` fire-and-forget pattern)
- \`useWebView.ts\` — add three \`case\` handlers in \`onMessage\` switch, forward to the helpers above

## Test plan
- [ ] Build the app, attach to Firebase DebugView
- [ ] Navigate web pages → \`screen_view\` events appear in DebugView
- [ ] Stay on a page > 1s, navigate → \`screen_dwell\` event with \`duration_ms\`
- [ ] Background + foreground → \`app_background\` / \`app_foreground\` events
- [ ] User properties show in Firebase Console after profile load