### PR TITLE
feat(analytics): forward ANALYTICS_TRACK_EVENT postMessages to Firebase

### DIFF
--- a/src/hooks/useWebView.ts
+++ b/src/hooks/useWebView.ts
@@ -1,6 +1,7 @@
 import { useFirebaseMessage, useNavigationService } from '@hooks';
 import {
   setAnalyticsUser,
+  trackEvent,
   trackScreenView,
   AnalyticsUserProperties,
 } from '../utils/analytics';
@@ -470,6 +471,11 @@ const useWebView = () => {
         case 'ANALYTICS_SET_USER': {
           const { user_id, ...properties } = data;
           setAnalyticsUser(user_id, properties as AnalyticsUserProperties);
+          return;
+        }
+        case 'ANALYTICS_TRACK_EVENT': {
+          const { name, params } = data;
+          trackEvent(name, params);
           return;
         }
         case 'WIDGET_DATA_UPDATED': {


### PR DESCRIPTION
## Summary

Mirror [PR #161](https://github.com/GooJinSun/WhoAmI-Today-app/pull/161) (merged to `main`) on this branch.

`main`'s PR added all three `ANALYTICS_*` cases at once. On `feature/widget` the analytics module was already restructured into `src/utils/analytics.ts` (replacing the deleted `useAnalytics.tsx`) and the `ANALYTICS_PAGE_VIEW` / `ANALYTICS_SET_USER` cases were wired to it — but the `ANALYTICS_TRACK_EVENT` case was missing.

Net effect on this branch right now: route changes and user properties forward to Firebase, while every `useTrackEvent`-emitted client event from the web frontend is silently dropped at the WebView bridge.

This PR adds the third case so the recently-added client-only tracking events (impression / scroll-depth / dwell, reaction picker, sign-up funnel, compose abandonment, dialog confirm/cancel, pick events — frontend PRs #1316–#1321) reach Firebase once `feature/widget` is shipped.

## Why not cherry-pick #161?

- `useAnalytics.tsx` exists on `main` but is deleted on `feature/widget` (logic moved into `utils/analytics.ts`) — cherry-pick would hit an add/delete conflict on that file.
- `useWebView.ts`'s import block + switch is structured very differently here, so the hunks wouldn't apply cleanly.

The only behavioral gap was the missing `ANALYTICS_TRACK_EVENT` case, so this PR adds exactly that — six lines.

## Diff

\`\`\`ts
import {
  setAnalyticsUser,
+ trackEvent,
  trackScreenView,
  AnalyticsUserProperties,
} from '../utils/analytics';
\`\`\`

\`\`\`ts
case 'ANALYTICS_SET_USER': { ... }
+ case 'ANALYTICS_TRACK_EVENT': {
+   const { name, params } = data;
+   trackEvent(name, params);
+   return;
+ }
case 'WIDGET_DATA_UPDATED': { ... }
\`\`\`

Frontend payload shape (from `src/hooks/useAppMessage.tsx` + `src/hooks/useTrackEvent.ts`): `{ actionType: 'ANALYTICS_TRACK_EVENT', name: string, params?: Record<string, string | number> }` — matches the destructure exactly.

## Test plan

- [ ] `yarn tsc --noemit` passes (verified locally — pre-commit hook ran clean)
- [ ] `yarn lint` introduces no new warnings (verified — 0 errors, 31 warnings all pre-existing)
- [ ] On a dev build, log into the web app and trigger any `useTrackEvent` call site (mission card click, share/compose action, dialog confirm) — confirm the corresponding event reaches Firebase Analytics DebugView
- [ ] Existing `ANALYTICS_PAGE_VIEW` (route change) and `ANALYTICS_SET_USER` (post-login profile load) continue to forward — no regression

## Follow-up

Once `feature/widget` itself is merged to `main`, the merge PR description should note that PR #161's forwarding intent is preserved through the `utils/analytics.ts` module structure on this branch.