### PR TITLE
feat(analytics): log widget_tapped on whoami:// deep link entry

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -13,6 +13,7 @@ import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { RouteType } from '@types';
 import NavigationService from '@libs/NavigationService';
 import { triggerWidgetRefresh } from './src/native/WidgetDataModule';
+import { trackWidgetTap } from './src/utils/widgetTapAnalytics';
 
 if (!__DEV__) {
   crashlytics().setCrashlyticsCollectionEnabled(true);
@@ -122,6 +123,7 @@ function buildLinking(
         return null; // Don't navigate within our app
       }
 
+      trackWidgetTap(url);
       return url;
     },
     subscribe(listener) {
@@ -155,6 +157,7 @@ function buildLinking(
         }
 
         console.log('[Deep Link] Passing URL to navigation:', url);
+        trackWidgetTap(url);
         listener(url);
 
         // Ensure AppScreen gets the URL when subscribe fires (e.g. cold start from widget)

--- a/src/utils/widgetTapAnalytics.ts
+++ b/src/utils/widgetTapAnalytics.ts
@@ -1,0 +1,85 @@
+import { trackEvent } from './analytics';
+
+type WidgetKind = 'album_cover' | 'photo' | 'checkin' | 'unauthenticated';
+type CheckinEditor = 'mood' | 'battery' | 'song' | 'thought';
+
+type WidgetTapInfo = {
+  widget_kind: WidgetKind;
+  editor?: CheckinEditor;
+};
+
+const VALID_EDITORS: readonly CheckinEditor[] = [
+  'mood',
+  'battery',
+  'song',
+  'thought',
+];
+
+function getQueryParam(url: string, key: string): string | null {
+  const queryIdx = url.indexOf('?');
+  if (queryIdx === -1) return null;
+  const query = url.slice(queryIdx + 1);
+  for (const pair of query.split('&')) {
+    const eq = pair.indexOf('=');
+    if (eq === -1) continue;
+    const k = pair.slice(0, eq);
+    if (k !== key) continue;
+    try {
+      return decodeURIComponent(pair.slice(eq + 1));
+    } catch {
+      return pair.slice(eq + 1);
+    }
+  }
+  return null;
+}
+
+export function parseWidgetTap(url: string): WidgetTapInfo | null {
+  if (!url || !url.startsWith('whoami://')) return null;
+  // Refresh URLs are widget-internal reloads, not user-facing taps.
+  const rest = url.slice('whoami://'.length).replace(/^\/+/, '');
+  if (rest.startsWith('widget-refresh') || rest.startsWith('widget/refresh')) {
+    return null;
+  }
+  if (rest.startsWith('app/login')) {
+    return { widget_kind: 'unauthenticated' };
+  }
+  if (rest.startsWith('app/discover')) {
+    return { widget_kind: 'album_cover' };
+  }
+  if (rest.startsWith('app/friends')) {
+    return { widget_kind: 'photo' };
+  }
+  if (rest.startsWith('app/update')) {
+    const editor = getQueryParam(url, 'editor');
+    if (editor && (VALID_EDITORS as readonly string[]).includes(editor)) {
+      return { widget_kind: 'checkin', editor: editor as CheckinEditor };
+    }
+    return { widget_kind: 'checkin' };
+  }
+  return null;
+}
+
+// Cold start can deliver the same URL through getInitialURL, then again through
+// the iOS onReady retry path. Dedup within a short window so we log once per tap.
+const DEDUP_TTL_MS = 10_000;
+let lastTracked: { url: string; at: number } | null = null;
+
+export function trackWidgetTap(url: string | null | undefined): void {
+  if (!url) return;
+  const info = parseWidgetTap(url);
+  if (!info) return;
+
+  const now = Date.now();
+  if (
+    lastTracked &&
+    lastTracked.url === url &&
+    now - lastTracked.at < DEDUP_TTL_MS
+  ) {
+    return;
+  }
+  lastTracked = { url, at: now };
+
+  const params: Record<string, string> = { widget_kind: info.widget_kind };
+  if (info.editor) params.editor = info.editor;
+  trackEvent('widget_tapped', params);
+}


### PR DESCRIPTION
## Summary

Widget taps land in the app via `whoami://app/*` deep links handled by `App.tsx`'s `buildLinking`. Until now those entries were tracked for navigation only — no analytics signal, so we couldn't see which widget kinds users actually engaged with.

This PR adds Firebase Analytics logging for widget taps via the `widget_tapped` event with a `widget_kind` param.

## How it works

URL pattern matching is sufficient for attribution because every `whoami://` producer in the codebase is a Swift widget (`ios/WhoAmITodayWidgets/*`) or an Android AppWidgetProvider (`android/.../widget/*Provider.java`) — no push noti or other deep-link source uses this scheme.

| URL pattern | `widget_kind` | extra params |
|---|---|---|
| `whoami://app/discover` | `album_cover` | — |
| `whoami://app/friends` | `photo` | — |
| `whoami://app/update?editor=mood\|battery\|song\|thought` | `checkin` | `editor` |
| `whoami://app/login` | `unauthenticated` | — |
| `whoami://widget-refresh*` | _(ignored — internal reload, not a tap)_ | — |

`trackWidgetTap` is called from both deep-link entry points:
- `getInitialURL()` — cold start (widget tap from app-killed state)
- `subscribe()` — warm start (widget tap while app already running)

A 10-second in-memory dedup window prevents double-logging when cold start delivers the same URL through both `getInitialURL` and the iOS `onReady` retry path.

## Files

- `src/utils/widgetTapAnalytics.ts` (new) — `parseWidgetTap` (URL → kind) + `trackWidgetTap` (with dedup) calling existing `trackEvent` from `utils/analytics.ts`
- `App.tsx` — single import + two one-line call sites in `getInitialURL` and `subscribe`

## Limitation / follow-up

The sign-in button is the same `whoami://app/login` URL on every widget kind, so `widget_kind: 'unauthenticated'` doesn't tell us which widget the user tapped. If per-widget breakdown of login-button taps becomes important, follow up by adding a `?widget_source=album_cover|photo|checkin` query param at each widget's URL construction site (8 native files: 4 iOS Swift widget files + 3 Android Java providers + bridge view) and extending the parser.

## Test plan

- [ ] `yarn tsc --noemit` clean (verified — pre-commit hook ran)
- [ ] `yarn lint` no new warnings (verified)
- [ ] Cold start via widget tap on iOS / Android → Firebase DebugView shows `widget_tapped` with correct `widget_kind`
- [ ] Warm start (app in background) widget tap → same event fires once (no duplicate)
- [ ] `widget-refresh*` URL → no event fires
- [ ] Existing deep-link navigation (Spotify URL handoff, widget refresh, normal `whoami://app/*` routing) unchanged