### PR TITLE
feat(widget): friend update widget shows most-recent activity (no random)

### DIFF
--- a/android/app/src/main/java/com/whoami/today/app/widget/PhotoWidgetProvider.java
+++ b/android/app/src/main/java/com/whoami/today/app/widget/PhotoWidgetProvider.java
@@ -339,15 +339,12 @@ public class PhotoWidgetProvider extends AppWidgetProvider {
                     return;
                 }
 
-                // Collect candidates (post OR checkin update)
+                // Collect candidates: any friend with a visible recent update
                 java.util.List<JSONObject> candidates = new java.util.ArrayList<>();
                 for (int i = 0; i < results.length(); i++) {
                     JSONObject friend = results.getJSONObject(i);
-                    boolean hasPost = friend.optInt("unread_post_cnt", 0) > 0
-                            || (friend.has("latest_unread_post") && !friend.isNull("latest_unread_post"));
-                    boolean hasCheckin = !friend.optBoolean("current_user_read", true)
-                            && friend.has("last_updated_field") && !friend.isNull("last_updated_field");
-                    if (hasPost || hasCheckin) {
+                    String ts = friend.optString("last_updated_at", "");
+                    if (!ts.isEmpty()) {
                         candidates.add(friend);
                     }
                 }
@@ -357,12 +354,14 @@ public class PhotoWidgetProvider extends AppWidgetProvider {
                     return;
                 }
 
-                JSONObject picked = candidates.get((int) (Math.random() * candidates.size()));
+                // Sort by last_updated_at desc (ISO 8601 lex order = chronological)
+                candidates.sort((a, b) -> b.optString("last_updated_at", "")
+                                          .compareTo(a.optString("last_updated_at", "")));
+                JSONObject picked = candidates.get(0);
                 String username = picked.optString("username", "");
                 String profileImageUrl = picked.optString("profile_image", "");
 
-                boolean preferPost = picked.optInt("unread_post_cnt", 0) > 0
-                        || (picked.has("latest_unread_post") && !picked.isNull("latest_unread_post"));
+                boolean preferPost = "post".equals(picked.optString("last_updated_kind", ""));
 
                 JSONObject friendUpdate = new JSONObject();
                 JSONObject friendJson = new JSONObject();
@@ -371,8 +370,13 @@ public class PhotoWidgetProvider extends AppWidgetProvider {
 
                 String contentImageBase64 = "";
 
-                if (preferPost && picked.has("latest_unread_post") && !picked.isNull("latest_unread_post")) {
-                    JSONObject post = picked.getJSONObject("latest_unread_post");
+                JSONArray recentPosts = picked.optJSONArray("recent_posts");
+                JSONObject recentPost = (recentPosts != null && recentPosts.length() > 0)
+                        ? recentPosts.optJSONObject(0)
+                        : null;
+
+                if (preferPost && recentPost != null) {
+                    JSONObject post = recentPost;
                     JSONArray images = post.optJSONArray("images");
                     boolean hasImage = images != null && images.length() > 0;
 

--- a/ios/WhoAmITodayWidgets/PhotoWidget.swift
+++ b/ios/WhoAmITodayWidgets/PhotoWidget.swift
@@ -70,25 +70,25 @@ struct PhotoWidgetProvider: TimelineProvider {
         guard let results = json["results"] as? [[String: Any]] else { return }
 
         let candidates: [[String: Any]] = results.filter { friend in
-            let hasPost = (friend["unread_post_cnt"] as? Int ?? 0) > 0
-                || !(friend["latest_unread_post"] is NSNull || friend["latest_unread_post"] == nil)
-            let currentUserRead = friend["current_user_read"] as? Bool ?? true
-            let lastUpdatedField = friend["last_updated_field"] as? String
-            let hasCheckin = !currentUserRead && (lastUpdatedField != nil)
-            return hasPost || hasCheckin
+            guard let ts = friend["last_updated_at"] as? String else { return false }
+            return !ts.isEmpty
         }
 
-        guard !candidates.isEmpty, let picked = candidates.randomElement() else { return }
+        guard !candidates.isEmpty,
+              let picked = candidates.max(by: {
+                  ($0["last_updated_at"] as? String ?? "") < ($1["last_updated_at"] as? String ?? "")
+              }) else { return }
         let username = picked["username"] as? String ?? ""
         let profileImageUrl = picked["profile_image"] as? String ?? ""
 
-        let preferPost = (picked["unread_post_cnt"] as? Int ?? 0) > 0
-            || !(picked["latest_unread_post"] is NSNull || picked["latest_unread_post"] == nil)
+        let preferPost = (picked["last_updated_kind"] as? String) == "post"
 
         var payload: [String: Any] = ["friend": ["username": username]]
         var contentImageUrl: URL? = nil
 
-        if preferPost, let post = picked["latest_unread_post"] as? [String: Any] {
+        if preferPost,
+           let posts = picked["recent_posts"] as? [[String: Any]],
+           let post = posts.first {
             let images = post["images"] as? [String] ?? []
             let hasImage = !images.isEmpty
             payload["kind"] = "post"

--- a/src/screens/AppScreen/AppScreen.tsx
+++ b/src/screens/AppScreen/AppScreen.tsx
@@ -606,9 +606,10 @@ const AppScreen: React.FC<AppScreenProps> = ({ route }) => {
           }
 
           // ── Friend update sync ──
-          // Picks a random friend with a check-in or post update and syncs one
-          // representative update (post prioritized over check-in) to the
-          // Friend Update Widget. Check-in variation follows last_updated_field.
+          // Picks the friend with the most recent visible update (post or
+          // check-in component) and syncs that update to the Friend Update
+          // Widget. Recency is sourced from backend `last_updated_at` and the
+          // post-vs-checkin choice from `last_updated_kind`.
           try {
             console.log(
               '[WidgetSync] Fetching friend list from /user/friends/',
@@ -668,20 +669,20 @@ const AppScreen: React.FC<AppScreenProps> = ({ route }) => {
               id: number;
               username: string;
               profile_image: string | null;
-              current_user_read: boolean;
-              unread_post_cnt: number;
-              latest_unread_post: {
-                id: number;
-                type: string;
-                content: string;
-                images: string[];
-              } | null;
+              last_updated_at: string | null;
+              last_updated_kind: 'post' | 'checkin' | null;
               last_updated_field:
                 | 'mood'
                 | 'social_battery'
                 | 'song'
                 | 'thought'
                 | null;
+              recent_posts?: Array<{
+                id: number;
+                type?: string;
+                content?: string;
+                images?: string[];
+              }>;
               mood: string[] | string | null;
               social_battery: string | null;
               thought: string | null;
@@ -709,22 +710,15 @@ const AppScreen: React.FC<AppScreenProps> = ({ route }) => {
               firstFriendSample: allFriends[0]
                 ? {
                     username: allFriends[0].username,
-                    current_user_read: allFriends[0].current_user_read,
-                    unread_post_cnt: allFriends[0].unread_post_cnt,
-                    has_latest_unread_post: !!allFriends[0].latest_unread_post,
+                    last_updated_at: allFriends[0].last_updated_at,
+                    last_updated_kind: allFriends[0].last_updated_kind,
                     last_updated_field: allFriends[0].last_updated_field,
+                    recent_posts_len: allFriends[0].recent_posts?.length ?? 0,
                   }
                 : null,
             });
 
-            const hasPostUpdate = (f: FriendItem) =>
-              (f.unread_post_cnt ?? 0) > 0 || !!f.latest_unread_post;
-            const hasCheckinUpdate = (f: FriendItem) =>
-              f.current_user_read === false && !!f.last_updated_field;
-
-            const candidates = allFriends.filter(
-              (f) => hasPostUpdate(f) || hasCheckinUpdate(f),
-            );
+            const candidates = allFriends.filter((f) => !!f.last_updated_at);
             console.log('[WidgetSync] Friend update candidates:', {
               total: allFriends.length,
               candidates: candidates.length,
@@ -735,30 +729,38 @@ const AppScreen: React.FC<AppScreenProps> = ({ route }) => {
               );
               await clearFriendUpdateFromWidget();
             } else {
-              const picked =
-                candidates[Math.floor(Math.random() * candidates.length)];
-              const preferPost = hasPostUpdate(picked);
+              const picked = candidates
+                .slice()
+                .sort((a, b) =>
+                  (b.last_updated_at ?? '').localeCompare(
+                    a.last_updated_at ?? '',
+                  ),
+                )[0];
+              const preferPost = picked.last_updated_kind === 'post';
               console.log('[WidgetSync] Picked friend:', {
                 username: picked.username,
                 kind: preferPost ? 'post' : 'checkin',
+                lastUpdatedAt: picked.last_updated_at,
                 lastUpdatedField: picked.last_updated_field,
               });
 
               let payload: FriendUpdatePayload | null = null;
               let contentImageBase64 = '';
 
-              if (preferPost && picked.latest_unread_post) {
-                const post = picked.latest_unread_post;
-                const hasImage = (post.images?.length ?? 0) > 0;
-                if (hasImage) {
-                  contentImageBase64 = await fetchImageAsBase64(post.images[0]);
+              const recentPost = picked.recent_posts?.[0];
+              if (preferPost && recentPost) {
+                const hasImage = (recentPost.images?.length ?? 0) > 0;
+                if (hasImage && recentPost.images?.[0]) {
+                  contentImageBase64 = await fetchImageAsBase64(
+                    recentPost.images[0],
+                  );
                 }
                 payload = {
                   kind: 'post',
                   friend: { username: picked.username },
                   post: {
-                    id: post.id,
-                    content: post.content ?? '',
+                    id: recentPost.id,
+                    content: recentPost.content ?? '',
                     has_image: hasImage,
                   },
                 };


### PR DESCRIPTION
## Summary
- Replaces the random-pick + unread-only filter with a deterministic "freshest update" feed in 3 selection sites in lockstep:
  - JS primary path: `src/screens/AppScreen/AppScreen.tsx`
  - iOS Swift fallback: `ios/WhoAmITodayWidgets/PhotoWidget.swift`
  - Android Java fallback: `android/app/src/main/java/com/whoami/today/app/widget/PhotoWidgetProvider.java`
- All three sort candidates by `last_updated_at` desc and pick `[0]`, then dispatch on `last_updated_kind`:
  - `'post'` → render from `recent_posts[0]` (unread filter dropped, so already-read recent posts can show too)
  - `'checkin'` → use existing `last_updated_field` to pick mood / battery / song / thought
- Result: widget reflects whoever updated most recently — including component-only PATCH (mood emoji change) — and stays put after the user reads, until something fresher comes in.

## Companion PR
- Backend: ssm0318/WhoamI-Today-backend#990 (`feat/widget-recent-update`) exposes the new `last_updated_at` and `last_updated_kind` fields. **Merge backend first.**

## Test plan
- [ ] `npx tsc --noEmit` clean (verified locally)
- [ ] `eslint` clean (0 errors, only existing console warnings — verified locally)
- [ ] Two friends each PATCH mood at 10s apart → JS sync log `[WidgetSync] Picked friend` shows the more recent one
- [ ] After reading the picked friend's content, widget stays on that friend (option B behavior — not unread-gated)
- [ ] iOS: clear App Group `friend_update` key, force timeline reload → fallback fetch picks most recent
- [ ] Android: clear SharedPreferences `friend_update`, broadcast `WIDGET_UPDATE` → fallback fetch picks most recent
- [ ] Post render: friend creates a note within last 24h → widget shows it via `recent_posts[0]` (image / content / hasImage all work)
- [ ] No regression on Check-in widget / Album cover widget (separate widgets, separate code paths)