### PR TITLE
fix(widget): refresh widgets every 10 min and unstick Shared Playlist random track

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -124,6 +124,15 @@
             android:resource="@xml/widget_info_album_2x2" />
     </receiver>
 
+    <!-- Self-rearming alarm tick that re-fetches widget data every 10 minutes -->
+    <receiver
+        android:name=".widget.WidgetRefreshTickReceiver"
+        android:exported="false">
+        <intent-filter>
+            <action android:name="com.whoami.today.app.WIDGET_REFRESH_TICK" />
+        </intent-filter>
+    </receiver>
+
     <!-- Check-in Widget (4x1) - Quick check-in access -->
     <receiver
         android:name=".widget.CheckinWidgetProvider"

--- a/android/app/src/main/java/com/whoami/today/app/MainApplication.java
+++ b/android/app/src/main/java/com/whoami/today/app/MainApplication.java
@@ -20,6 +20,7 @@ import android.os.Build;
 import org.jetbrains.annotations.Nullable;
 
 import com.whoami.today.app.bridge.WidgetDataPackage;
+import com.whoami.today.app.widget.WidgetRefreshScheduler;
 
 public class MainApplication extends Application implements ReactApplication {
 
@@ -81,5 +82,10 @@ public class MainApplication extends Application implements ReactApplication {
       // If you opted-in for the New Architecture, we load the native entry point for this app.
       DefaultNewArchitectureEntryPoint.load();
     }
+
+    // Re-arm the widget refresh tick on every cold start: the alarm gets cancelled
+    // when the app is force-stopped or the package is reinstalled, so onEnabled
+    // alone isn't enough to keep widgets refreshing for long-running installs.
+    WidgetRefreshScheduler.scheduleNext(this);
   }
 }

--- a/android/app/src/main/java/com/whoami/today/app/widget/AlbumCoverWidgetProvider.java
+++ b/android/app/src/main/java/com/whoami/today/app/widget/AlbumCoverWidgetProvider.java
@@ -64,6 +64,26 @@ public class AlbumCoverWidgetProvider extends AppWidgetProvider {
                 }
             }
         }
+
+        // Always re-fetch on each system update tick so a new random track from
+        // the shared playlist surfaces without the user opening the app, and
+        // the widget doesn't stay stuck on whichever track was first cached.
+        SharedPreferences prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+        String accessToken = prefs.getString("access_token", "");
+        String versionType = prefs.getString("user_version_type", VERSION_TYPE_DEFAULT);
+        if (accessToken != null && !accessToken.isEmpty()
+                && !VERSION_TYPE_DEFAULT.equals(versionType)
+                && !VERSION_TYPE_Q.equals(versionType)) {
+            for (int appWidgetId : appWidgetIds) {
+                fetchSharedPlaylistFromApi(context, appWidgetManager, appWidgetId, prefs);
+            }
+        }
+    }
+
+    @Override
+    public void onEnabled(Context context) {
+        super.onEnabled(context);
+        WidgetRefreshScheduler.scheduleNext(context);
     }
 
     @Override

--- a/android/app/src/main/java/com/whoami/today/app/widget/PhotoWidgetProvider.java
+++ b/android/app/src/main/java/com/whoami/today/app/widget/PhotoWidgetProvider.java
@@ -85,6 +85,12 @@ public class PhotoWidgetProvider extends AppWidgetProvider {
     }
 
     @Override
+    public void onEnabled(Context context) {
+        super.onEnabled(context);
+        WidgetRefreshScheduler.scheduleNext(context);
+    }
+
+    @Override
     public void onReceive(Context context, Intent intent) {
         super.onReceive(context, intent);
         String action = intent.getAction();

--- a/android/app/src/main/java/com/whoami/today/app/widget/WidgetRefreshScheduler.java
+++ b/android/app/src/main/java/com/whoami/today/app/widget/WidgetRefreshScheduler.java
@@ -1,0 +1,55 @@
+package com.whoami.today.app.widget;
+
+import android.app.AlarmManager;
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Build;
+import android.os.SystemClock;
+import android.util.Log;
+
+/**
+ * AppWidget XML's {@code updatePeriodMillis} is clamped to 30 minutes by the
+ * system, which is too long for the friend update / shared playlist widgets.
+ * This scheduler registers a self-rearming alarm so the widgets re-fetch and
+ * re-render roughly every 10 minutes even while the host app is closed.
+ */
+public class WidgetRefreshScheduler {
+    private static final String TAG = "WidgetRefreshScheduler";
+    private static final long INTERVAL_MS = 10L * 60L * 1000L;
+    static final String ACTION_TICK = "com.whoami.today.app.WIDGET_REFRESH_TICK";
+    private static final int REQUEST_CODE = 4711;
+
+    public static void scheduleNext(Context context) {
+        if (context == null) return;
+        AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
+        if (alarmManager == null) {
+            Log.w(TAG, "AlarmManager not available");
+            return;
+        }
+
+        long triggerAt = SystemClock.elapsedRealtime() + INTERVAL_MS;
+        PendingIntent pending = buildPendingIntent(context);
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                alarmManager.setAndAllowWhileIdle(AlarmManager.ELAPSED_REALTIME_WAKEUP, triggerAt, pending);
+            } else {
+                alarmManager.set(AlarmManager.ELAPSED_REALTIME_WAKEUP, triggerAt, pending);
+            }
+            Log.d(TAG, "Scheduled next widget refresh in " + (INTERVAL_MS / 1000) + "s");
+        } catch (Exception e) {
+            Log.e(TAG, "Failed to schedule widget refresh", e);
+        }
+    }
+
+    private static PendingIntent buildPendingIntent(Context context) {
+        Intent intent = new Intent(context, WidgetRefreshTickReceiver.class);
+        intent.setAction(ACTION_TICK);
+        return PendingIntent.getBroadcast(
+                context.getApplicationContext(),
+                REQUEST_CODE,
+                intent,
+                PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE
+        );
+    }
+}

--- a/android/app/src/main/java/com/whoami/today/app/widget/WidgetRefreshTickReceiver.java
+++ b/android/app/src/main/java/com/whoami/today/app/widget/WidgetRefreshTickReceiver.java
@@ -1,0 +1,45 @@
+package com.whoami.today.app.widget;
+
+import android.appwidget.AppWidgetManager;
+import android.content.BroadcastReceiver;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.util.Log;
+
+/**
+ * Fires every {@code WidgetRefreshScheduler.INTERVAL_MS}; broadcasts a normal
+ * APPWIDGET_UPDATE to each widget provider so their existing onUpdate path runs,
+ * then reschedules itself.
+ */
+public class WidgetRefreshTickReceiver extends BroadcastReceiver {
+    private static final String TAG = "WidgetRefreshTick";
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        if (context == null || intent == null) return;
+        if (!WidgetRefreshScheduler.ACTION_TICK.equals(intent.getAction())) return;
+
+        Log.d(TAG, "Tick received, dispatching widget updates");
+        dispatchUpdate(context, PhotoWidgetProvider.class);
+        dispatchUpdate(context, AlbumCoverWidgetProvider.class);
+
+        WidgetRefreshScheduler.scheduleNext(context);
+    }
+
+    private void dispatchUpdate(Context context, Class<?> providerClass) {
+        try {
+            AppWidgetManager mgr = AppWidgetManager.getInstance(context);
+            ComponentName component = new ComponentName(context, providerClass);
+            int[] ids = mgr.getAppWidgetIds(component);
+            if (ids == null || ids.length == 0) return;
+
+            Intent update = new Intent(context, providerClass);
+            update.setAction(AppWidgetManager.ACTION_APPWIDGET_UPDATE);
+            update.putExtra(AppWidgetManager.EXTRA_APPWIDGET_IDS, ids);
+            context.sendBroadcast(update);
+        } catch (Exception e) {
+            Log.e(TAG, "Failed to dispatch update for " + providerClass.getSimpleName(), e);
+        }
+    }
+}

--- a/ios/WhoAmITodayWidgets/AlbumCoverWidget.swift
+++ b/ios/WhoAmITodayWidgets/AlbumCoverWidget.swift
@@ -101,12 +101,14 @@ struct AlbumCoverWidgetProvider: TimelineProvider {
             sharerUsername: track?.sharerUsername
         )
 
-        let nextUpdate = Calendar.current.date(byAdding: .minute, value: 15, to: Date())!
+        let nextUpdate = Calendar.current.date(byAdding: .minute, value: 10, to: Date())!
         let timeline = Timeline(entries: [entry], policy: .after(nextUpdate))
         completion(timeline)
 
-        // Fire-and-forget: self-fetch when no cached data
-        if isAuth && !isDefault && !isVersionQ && albumImageData == nil && avatarImageData == nil {
+        // Fire-and-forget self-fetch on every tick so a new random track from
+        // the shared playlist surfaces without the user opening the app, and
+        // the widget doesn't get stuck on whichever track was first cached.
+        if isAuth && !isDefault && !isVersionQ {
             Task.detached {
                 await Self.fetchSharedPlaylistFromApi()
             }

--- a/ios/WhoAmITodayWidgets/PhotoWidget.swift
+++ b/ios/WhoAmITodayWidgets/PhotoWidget.swift
@@ -55,7 +55,7 @@ struct PhotoWidgetProvider: TimelineProvider {
 
     func getTimeline(in context: Context, completion: @escaping (Timeline<PhotoWidgetEntry>) -> Void) {
         let entry = currentEntry(source: "timeline")
-        let nextUpdate = Calendar.current.date(byAdding: .minute, value: 15, to: Date())!
+        let nextUpdate = Calendar.current.date(byAdding: .minute, value: 10, to: Date())!
         let timeline = Timeline(entries: [entry], policy: .after(nextUpdate))
         completion(timeline)
 


### PR DESCRIPTION
## Summary

Two bugs were combining to make the home-screen widgets feel dead between app launches:

- **Shared Playlist widget always showed the same song.** Both iOS (`AlbumCoverWidget.swift`) and Android (`AlbumCoverWidgetProvider.java`) only ran the self-fetch when the cached image was empty. Once a track was cached the existing `randomElement()` / `Math.random()` selection never re-ran.
- **Refresh hint was too long.** iOS used 15 minutes, Android relied on `updatePeriodMillis` which the system clamps to 30 minutes.

Changes:

- **iOS** — drop the nil guard so every `getTimeline` tick re-fetches a random track; lower the reload hint to 10 min on both widgets.
- **Android (Shared Playlist)** — mirror PhotoWidget's onUpdate-time fetch so each refresh picks a new track.
- **Android (10-min cadence)** — new `WidgetRefreshScheduler` registers a self-rearming `setAndAllowWhileIdle` alarm and `WidgetRefreshTickReceiver` broadcasts `APPWIDGET_UPDATE` to both providers on each tick. The alarm is armed in each provider's `onEnabled` and re-armed on every cold start in `MainApplication` to survive force-stops and reinstalls.

No Spotify keys involved — both widgets use Spotify oEmbed (no auth) so this PR doesn't touch any credentials.

### Caveat

iOS `policy: .after(date)` is a hint and the system can stretch it under WidgetKit budget. Android `setAndAllowWhileIdle` can be deferred a few minutes by Doze. So "every 10 min" isn't guaranteed — but the average is shorter than before, and the cache-guard bug that caused the Shared Playlist to never change is fully removed.

## Test plan

- [ ] iOS simulator: add both widgets, observe `AlbumCoverWidget.getTimeline` heartbeat in App Group diagnostics — confirm Shared Playlist track changes across reload ticks
- [ ] iOS simulator: post a new friend update from another account, confirm Friend Update widget reflects it on the next reload tick
- [ ] Android device: add both widgets, `adb shell dumpsys alarm | grep com.whoami.today.app` shows the registered tick alarm
- [ ] Android device: `adb logcat -s WidgetRefreshTick FriendUpdateWidget AlbumCoverWidget` shows ticks roughly every 10 min while app is backgrounded
- [ ] Android device: Shared Playlist track changes between ticks
- [ ] Android device: force-stop app, verify alarm is re-armed on next launch